### PR TITLE
Adicionando suporte ao Django 1.6

### DIFF
--- a/django_pagseguro/urls.py
+++ b/django_pagseguro/urls.py
@@ -1,6 +1,7 @@
 #-*- coding: utf-8 -*-
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 from django.conf import settings
+
 
 def pagseguro_urlpatterns(url_name='django_pagseguro_retorno'):
     """
@@ -10,7 +11,8 @@ def pagseguro_urlpatterns(url_name='django_pagseguro_retorno'):
             settings.PAGSEGURO_URL_RETORNO = '/pagseguro/retorno/'
     """
     url_retorno = settings.PAGSEGURO_URL_RETORNO.lstrip('/')
-    urlpatterns = patterns('django_pagseguro.views',
+    urlpatterns = patterns(
+        'django_pagseguro.views',
         url(r'^%s$' % url_retorno, 'retorno', name=url_name),
     )
     return urlpatterns

--- a/django_pagseguro/urls.py
+++ b/django_pagseguro/urls.py
@@ -1,5 +1,8 @@
 #-*- coding: utf-8 -*-
-from django.conf.urls import patterns, url
+try:
+    from django.conf.urls import patterns, url
+except ImportError:
+    from django.conf.urls.defaults import patterns, url
 from django.conf import settings
 
 


### PR DESCRIPTION
O import "from django.conf.urls.defaults import patterns, url" foi removido do Django 1.6, agora é necessário importar "from django.conf.urls import patterns, url"
